### PR TITLE
feat: add login and register screens

### DIFF
--- a/src/walking_skel/walking-skel/app/components/InfoModal.tsx
+++ b/src/walking_skel/walking-skel/app/components/InfoModal.tsx
@@ -1,0 +1,40 @@
+type InfoModalProps = {
+  title: string;
+  message: string;
+  onClose: () => void;
+};
+
+// Small popup used to show a single info/error message, with an "OK" button to close it.
+// Pulled out into its own file so it can be reused by any form (login, create habit, ...)
+// without copy-pasting the same markup everywhere.
+export default function InfoModal({ title, message, onClose }: InfoModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      <div className="absolute inset-0 bg-black/20 backdrop-blur-sm" onClick={onClose} />
+      <div
+        className="relative w-full max-w-md bg-white border border-[var(--text)] p-6"
+        style={{ borderRadius: 'var(--radius-lg)' }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="info-modal-title"
+        aria-describedby="info-modal-message"
+      >
+        <h2 id="info-modal-title" className="text-lg font-bold text-[var(--text)]">
+          {title}
+        </h2>
+        <p id="info-modal-message" className="mt-2 text-[var(--text-2)]">
+          {message}
+        </p>
+        <div className="mt-6 flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full px-4 py-2 text-sm font-semibold bg-[var(--teal-500)] text-white transition-transform hover:-translate-y-0.5 active:translate-y-0"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/walking_skel/walking-skel/app/login/LoginForm.tsx
+++ b/src/walking_skel/walking-skel/app/login/LoginForm.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link';
+
+const inputClass =
+  'w-full px-4 py-2 border border-[var(--text)] focus:outline-none focus:ring-2 focus:ring-[var(--focus)] bg-white text-[var(--text)]';
+
+type LoginFormProps = {
+  email: string;
+  password: string;
+  loading: boolean;
+  onEmailChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+};
+
+// The actual email/password form, separated from page.tsx so that file
+// only has to deal with page layout and state, not the form markup.
+export default function LoginForm({
+  email,
+  password,
+  loading,
+  onEmailChange,
+  onPasswordChange,
+  onSubmit,
+}: LoginFormProps) {
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="bg-white p-8 border border-[var(--text)]"
+      style={{ borderRadius: 'var(--radius-lg)' }}
+    >
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-[var(--text-2)] mb-2">Email</label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => onEmailChange(e.target.value)}
+          placeholder="you@example.com"
+          className={inputClass}
+        />
+      </div>
+
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-[var(--text-2)] mb-2">Password</label>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => onPasswordChange(e.target.value)}
+          placeholder="••••••••"
+          className={inputClass}
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full text-white font-semibold py-2 px-6 transition transition-transform hover:-translate-y-0.5 active:translate-y-0"
+        style={{
+          background: 'linear-gradient(135deg, var(--teal-500), var(--teal-700))',
+          opacity: loading ? 0.7 : 1,
+        }}
+      >
+        {loading ? 'Logging in...' : 'Log In'}
+      </button>
+
+      <p className="mt-6 text-center text-sm text-[var(--text-2)]">
+        Don&apos;t have an account?{' '}
+        <Link href="/register" className="text-[var(--teal-700)] font-semibold hover:text-[var(--teal-900)]">
+          Sign up
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/src/walking_skel/walking-skel/app/login/page.tsx
+++ b/src/walking_skel/walking-skel/app/login/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import LoginForm from './LoginForm';
+import InfoModal from '@/app/components/InfoModal';
+
+// Login screen - UI only for now, auth wiring (Supabase signInWithPassword) follows later
+//
+// Split into smaller files so each one fits on a screen (~60 lines):
+// - LoginForm.tsx: the email/password form
+// - components/InfoModal.tsx: the shared "info/error" popup
+export default function LoginPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [modal, setModal] = useState<{ title: string; message: string } | null>(null);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!email.trim() || !password.trim()) {
+      setModal({ title: 'Missing info', message: 'Please enter your email and password.' });
+      return;
+    }
+
+    setLoading(true);
+    router.push('/');
+    // TODO: Replace with Supabase auth.signInWithPassword({ email, password })
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-[var(--page-bg)] flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <p className="text-2xl font-extrabold tracking-[0.18em] text-[var(--teal-700)] uppercase">
+            Habito
+          </p>
+          <h2 className="text-2xl font-semibold text-[var(--teal-900)] mt-1">Welcome back</h2>
+          <p className="text-[var(--text-2)] mt-1">Log in to continue tracking your habits.</p>
+        </div>
+
+        <LoginForm
+          email={email}
+          password={password}
+          loading={loading}
+          onEmailChange={setEmail}
+          onPasswordChange={setPassword}
+          onSubmit={handleSubmit}
+        />
+
+        {modal && (
+          <InfoModal title={modal.title} message={modal.message} onClose={() => setModal(null)} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/walking_skel/walking-skel/app/register/RegisterForm.tsx
+++ b/src/walking_skel/walking-skel/app/register/RegisterForm.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+
+const inputClass =
+  'w-full px-4 py-2 border border-[var(--text)] focus:outline-none focus:ring-2 focus:ring-[var(--focus)] bg-white text-[var(--text)]';
+
+type RegisterFormProps = {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  loading: boolean;
+  onEmailChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onConfirmPasswordChange: (value: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+};
+
+// The actual email/password/confirm-password form, separated from page.tsx so that
+// file only has to deal with page layout and state, not the form markup.
+export default function RegisterForm({
+  email,
+  password,
+  confirmPassword,
+  loading,
+  onEmailChange,
+  onPasswordChange,
+  onConfirmPasswordChange,
+  onSubmit,
+}: RegisterFormProps) {
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="bg-white p-8 border border-[var(--text)]"
+      style={{ borderRadius: 'var(--radius-lg)' }}
+    >
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-[var(--text-2)] mb-2">Email</label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => onEmailChange(e.target.value)}
+          placeholder="you@example.com"
+          className={inputClass}
+        />
+      </div>
+
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-[var(--text-2)] mb-2">Password</label>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => onPasswordChange(e.target.value)}
+          placeholder="••••••••"
+          className={inputClass}
+        />
+      </div>
+
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-[var(--text-2)] mb-2">Confirm Password</label>
+        <input
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => onConfirmPasswordChange(e.target.value)}
+          placeholder="••••••••"
+          className={inputClass}
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full text-white font-semibold py-2 px-6 transition transition-transform hover:-translate-y-0.5 active:translate-y-0"
+        style={{
+          background: 'linear-gradient(135deg, var(--teal-500), var(--teal-700))',
+          opacity: loading ? 0.7 : 1,
+        }}
+      >
+        {loading ? 'Creating account...' : 'Sign Up'}
+      </button>
+
+      <p className="mt-6 text-center text-sm text-[var(--text-2)]">
+        Already have an account?{' '}
+        <Link href="/login" className="text-[var(--teal-700)] font-semibold hover:text-[var(--teal-900)]">
+          Log in
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/src/walking_skel/walking-skel/app/register/page.tsx
+++ b/src/walking_skel/walking-skel/app/register/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import RegisterForm from './RegisterForm';
+import InfoModal from '@/app/components/InfoModal';
+
+// Register screen - UI only for now, auth wiring (Supabase auth.signUp) follows later
+export default function RegisterPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [modal, setModal] = useState<{ title: string; message: string } | null>(null);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!email.trim() || !password.trim() || !confirmPassword.trim()) {
+      setModal({ title: 'Missing info', message: 'Please fill in all fields.' });
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setModal({ title: 'Passwords do not match', message: 'Please make sure both passwords are the same.' });
+      return;
+    }
+
+    setLoading(true);
+    // TODO: Replace with Supabase auth.signUp({ email, password })
+    router.push('/');
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-[var(--page-bg)] flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <p className="text-2xl font-extrabold tracking-[0.18em] text-[var(--teal-700)] uppercase">
+            Habito
+          </p>
+          <h2 className="text-2xl font-semibold text-[var(--teal-900)] mt-1">Create your account</h2>
+          <p className="text-[var(--text-2)] mt-1">Sign up to start tracking your habits.</p>
+        </div>
+
+        <RegisterForm
+          email={email}
+          password={password}
+          confirmPassword={confirmPassword}
+          loading={loading}
+          onEmailChange={setEmail}
+          onPasswordChange={setPassword}
+          onConfirmPasswordChange={setConfirmPassword}
+          onSubmit={handleSubmit}
+        />
+
+        {modal && (
+          <InfoModal title={modal.title} message={modal.message} onClose={() => setModal(null)} />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add /login page with email/password form, client-side validation, and redirect to / on submit
- Add /register page with email/password/confirm-password form, validation, and redirect to / on submit
- Add shared InfoModal component for error/info popups, reused by both forms

## Test plan
- Run `npm run dev` and visit /login and /register
- Verify validation errors show in the modal (empty fields, mismatched passwords)
- Verify links between /login and /register work
- Verify successful submit redirects to /

Note: Auth is not yet wired to Supabase (signInWithPassword / signUp) - left as TODO.